### PR TITLE
Simplify TaxPayer models

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,9 +32,14 @@ releases, in reverse chronological order.
             # You can customise the filename here.
             # This is the default behaviour:
             return f"{self.receipt.formatted_number}.pdf"
+
 * QR Codes have been implemented and replace barcodes in receipts. If you use
   custom receipt templates, you'll need to update them. The provided template
   should serve as a reference.
+* The fields from the ``TaxPayerExtras`` have moved into the ``TaxPayer``
+  model. A migration will handle copying data from table to the other for you.
+  If you have any references to this model (e.g.: forms for your users, custom
+  admins, etc), make sure you update these to point to the ``TaxPayer`` model.
 
 7.1.2
 -----

--- a/django_afip/factories.py
+++ b/django_afip/factories.py
@@ -97,6 +97,7 @@ class TaxPayerFactory(DjangoModelFactory):
     key = FileField(from_func=_key_file)
     certificate = FileField(from_func=_cert_file)
     active_since = datetime(2011, 10, 3)
+    logo = ImageField(from_func=_tiny_image_file)
 
 
 class AlternateTaxpayerFactory(DjangoModelFactory):
@@ -221,11 +222,3 @@ class TaxFactory(DjangoModelFactory):
     base_amount = 100
     receipt = SubFactory(ReceiptFactory)
     tax_type = SubFactory(TaxTypeFactory)
-
-
-class TaxPayerExtras(DjangoModelFactory):
-    class Meta:
-        model = models.TaxPayerExtras
-
-    taxpayer = SubFactory(TaxPayerFactory)
-    logo = ImageField(from_func=_tiny_image_file)

--- a/django_afip/migrations/0005_flatten_taxpayer_extras.py
+++ b/django_afip/migrations/0005_flatten_taxpayer_extras.py
@@ -1,0 +1,33 @@
+import django.core.files.storage
+from django.db import migrations
+from django.db import models
+
+
+def merge_taxpayer_extras(apps, schema_editor):
+    TaxPayerExtras = apps.get_model("afip", "TaxPayerExtras")
+
+    for extras in TaxPayerExtras.objects.all():
+        extras.taxpayer.logo = extras.logo
+        extras.taxpayer.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("afip", "0004_storages_and_help_texts"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="taxpayer",
+            name="logo",
+            field=models.ImageField(
+                blank=True,
+                help_text="A logo to use when generating printable receipts.",
+                null=True,
+                storage=django.core.files.storage.FileSystemStorage(),
+                upload_to="afip/taxpayers/logos/",
+                verbose_name="logo",
+            ),
+        ),
+        migrations.RunPython(merge_taxpayer_extras),
+    ]

--- a/django_afip/migrations/0005_flatten_taxpayer_extras.py
+++ b/django_afip/migrations/0005_flatten_taxpayer_extras.py
@@ -6,7 +6,7 @@ from django.db import models
 def merge_taxpayer_extras(apps, schema_editor):
     TaxPayerExtras = apps.get_model("afip", "TaxPayerExtras")
 
-    for extras in TaxPayerExtras.objects.all():
+    for extras in TaxPayerExtras.objects.all():  # pragma: no cover
         extras.taxpayer.logo = extras.logo
         extras.taxpayer.save()
 

--- a/django_afip/migrations/0006_delete_taxpayerextras.py
+++ b/django_afip/migrations/0006_delete_taxpayerextras.py
@@ -1,0 +1,14 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("afip", "0005_flatten_taxpayer_extras"),
+    ]
+
+    operations = [
+        migrations.DeleteModel(
+            name="TaxPayerExtras",
+        ),
+    ]

--- a/django_afip/templates/receipts/code_6.html
+++ b/django_afip/templates/receipts/code_6.html
@@ -14,8 +14,8 @@
       <header>
         <div class="taxpayer-details group">
           <address>
-            {% if extras and extras.logo %}
-              <img src="{{ extras.logo_as_data_uri }}" alt="Logo"><br>
+            {% if taxpayer.logo %}
+              <img src="{{ taxpayer.logo_as_data_uri }}" alt="Logo"><br>
             {% endif %}
             <strong>{{ pdf.issuing_name }}</strong><br>
             {{ pdf.issuing_address|linebreaksbr }}<br>

--- a/django_afip/views.py
+++ b/django_afip/views.py
@@ -94,13 +94,9 @@ class ReceiptPDFView(PDFView):
             )
         )
         taxpayer = receipt_pdf.receipt.point_of_sales.owner
-        extras = models.TaxPayerExtras.objects.filter(
-            taxpayer=taxpayer,
-        ).first()
 
         context["pdf"] = receipt_pdf
         context["taxpayer"] = taxpayer
-        context["extras"] = extras
         context["qrcode"] = get_encoded_qrcode(receipt_pdf)
 
         return context

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -32,8 +32,6 @@ unless you intend to generate PDFs for receipts.
     :members:
 .. autoclass:: django_afip.models.TaxPayerProfile
     :members:
-.. autoclass:: django_afip.models.TaxPayerExtras
-    :members:
 
 Metadata models
 ---------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -46,7 +46,7 @@ work just fine. See the django documentation for more details on storages.
     AFIP_KEY_STORAGE  # Keys for authenticating with AFIP (TaxPayer.key)
     AFIP_CERT_STORAGE  # Certs for auth'ing with AFIP (TaxPayer.certificate)
     AFIP_PDF_STORAGE  # PDFs generated for receipts (ReceiptPDF.pdf_file)
-    AFIP_LOGO_STORAGE  # Logos used in invoices (TaxPayerExtras.logo)
+    AFIP_LOGO_STORAGE  # Logos used in invoices (TaxPayer.logo)
 
 
 Versioning

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,3 +18,6 @@ addopts =
 markers =
   live: Tests done with the live test environment.
 DJANGO_SETTINGS_MODULE = testapp.settings
+
+[mypy]
+ignore_missing_imports = True

--- a/testapp/testapp/testmain/tests/test_views.py
+++ b/testapp/testapp/testmain/tests/test_views.py
@@ -16,6 +16,7 @@ class ReceiptPDFTestCase(TestCase):
             receipt__concept__code=1,
             receipt__issued_date=date(2017, 5, 15),
             receipt__receipt_type__code=11,
+            receipt__point_of_sales__owner__logo=None,
         )
         factories.ReceiptValidationFactory(receipt=pdf.receipt)
 
@@ -140,7 +141,6 @@ class ReceiptPDFTestCase(TestCase):
         """Test the HTML generation view."""
         pdf = factories.ReceiptPDFFactory()
         factories.ReceiptValidationFactory(receipt=pdf.receipt)
-        factories.TaxPayerExtras(taxpayer=pdf.receipt.point_of_sales.owner)
 
         client = Client()
         response = client.get(


### PR DESCRIPTION
The original intent of this library was to provide only receipt validation, when printable were later implemented, they were designed as an "optional" extra.

Because of this, the fields required for printing [but not validating] were kept in different tables. This has been very confusing for users. I've gotten lots of emails, and, ultimately, it seems it was bad design, since everyone also wants to use this library to generate the PDFs too.

See changelog for finer details.