### PR TITLE
Run all CI tests nightly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: Tests
 
-on: [push]
+on:
+  push:
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   tests:


### PR DESCRIPTION
For some reason I assumed this was the case, but it's not.

Should make sure there's not breakage from upstream. Especially for infrequently used endpoints.