### PR TITLE
Update cryptography to 3.2.0

### DIFF
--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -678,13 +678,11 @@ class AuthTicket(models.Model):
         return etree.tostring(request_xml, pretty_print=True)
 
     def __sign_request(self, request):
-        self.owner.certificate.file.open()
-        cert = self.owner.certificate.file.read().decode()
-        self.owner.certificate.file.close()
+        with self.owner.certificate.file.open("rb") as f:
+            cert = f.read()
 
-        self.owner.key.file.open()
-        key = self.owner.key.file.read()
-        self.owner.key.file.close()
+        with self.owner.key.file.open("rb") as f:
+            key = f.read()
 
         return crypto.create_embeded_pkcs7_signature(request, cert, key)
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     include_package_data=True,
     long_description=open("README.rst").read(),
     install_requires=[
-        "cryptography<3.1",
+        "cryptography>=3.2,<4.0",
         "django>=2.0.0,<=3.1",
         "django_renderpdf>=3.0.0,<4.0.0",
         "lxml>=3.4.4",

--- a/testapp/conftest.py
+++ b/testapp/conftest.py
@@ -9,12 +9,12 @@ def base_path() -> Path:
 
 
 @pytest.fixture
-def expired_crt(base_path) -> str:
-    with open(base_path.joinpath("test_expired.crt")) as crt:
+def expired_crt(base_path) -> bytes:
+    with open(base_path.joinpath("test_expired.crt"), "rb") as crt:
         return crt.read()
 
 
 @pytest.fixture
-def expired_key(base_path) -> str:
-    with open(base_path.joinpath("test_expired.key")) as key:
+def expired_key(base_path) -> bytes:
+    with open(base_path.joinpath("test_expired.key"), "rb") as key:
         return key.read()

--- a/testapp/testapp/testmain/tests/test_crypto.py
+++ b/testapp/testapp/testmain/tests/test_crypto.py
@@ -9,7 +9,7 @@ def signed_data(base_path):
         return data.read()
 
 
-def test_pkcs7_signing(expired_key, expired_crt, signed_data):
+def test_pkcs7_signing(expired_key: bytes, expired_crt: bytes, signed_data: bytes):
     # Use an expired cert here since this won't change on a yearly basis.
     data = b"Some data."
 


### PR DESCRIPTION
Version 3.1.0 has dropped some undocumented interfaces and broke our crypto integration. v3.2.0 not includes the features we need as supported features. Adopt the new interface, and pin cryptography.

Fixes #52