### PR TITLE
Include metadata as fixtures

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,12 @@ releases, in reverse chronological order.
   model. A migration will handle copying data from table to the other for you.
   If you have any references to this model (e.g.: forms for your users, custom
   admins, etc), make sure you update these to point to the ``TaxPayer`` model.
+* Fixtures are now included with all necessary metadata (currencies, receipt
+  types, etc). This should make bootstrapping new projects and environments
+  easier.
+* The function ``models.populate_all`` has been removed in favour of
+  :func:`~.models.loaddata`. The ``afipmetadata`` management command now runs
+  the latter.
 
 7.1.2
 -----

--- a/django_afip/fixtures/concepttype.yaml
+++ b/django_afip/fixtures/concepttype.yaml
@@ -1,0 +1,18 @@
+- model: afip.concepttype
+  fields:
+    code: '1'
+    description: Producto
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.concepttype
+  fields:
+    code: '2'
+    description: Servicios
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.concepttype
+  fields:
+    code: '3'
+    description: Productos y Servicios
+    valid_from: 2010-09-17
+    valid_to: null

--- a/django_afip/fixtures/currencytype.yaml
+++ b/django_afip/fixtures/currencytype.yaml
@@ -1,0 +1,300 @@
+- model: afip.currencytype
+  fields:
+    code: PES
+    description: Pesos Argentinos
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: DOL
+    description: Dólar Estadounidense
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '002'
+    description: Dólar Libre EEUU
+    valid_from: 2009-04-16
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '007'
+    description: Florines Holandeses
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '010'
+    description: Pesos Mejicanos
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '011'
+    description: Pesos Uruguayos
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '014'
+    description: Coronas Danesas
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '015'
+    description: Coronas Noruegas
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '016'
+    description: Coronas Suecas
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: 018
+    description: Dólar Canadiense
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: 019
+    description: Yens
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '021'
+    description: Libra Esterlina
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '023'
+    description: Bolívar Venezolano
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '024'
+    description: Corona Checa
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '025'
+    description: Dinar Yugoslavo
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '026'
+    description: Dólar Australiano
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '027'
+    description: Dracma Griego
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: 028
+    description: Florín (Antillas Holandesas)
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: 029
+    description: Güaraní
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '031'
+    description: Peso Boliviano
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '032'
+    description: Peso Colombiano
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '033'
+    description: Peso Chileno
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '034'
+    description: Rand Sudafricano
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '036'
+    description: Sucre Ecuatoriano
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '051'
+    description: Dólar de Hong Kong
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '052'
+    description: Dólar de Singapur
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '053'
+    description: Dólar de Jamaica
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '054'
+    description: Dólar de Taiwan
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '055'
+    description: Quetzal Guatemalteco
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '056'
+    description: Forint (Hungría)
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '057'
+    description: Baht (Tailandia)
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: 059
+    description: Dinar Kuwaiti
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '012'
+    description: Real
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '030'
+    description: Shekel (Israel)
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '035'
+    description: Nuevo Sol Peruano
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '060'
+    description: Euro
+    valid_from: 2009-04-03
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '040'
+    description: Lei Rumano
+    valid_from: 2009-04-15
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '042'
+    description: Peso Dominicano
+    valid_from: 2009-04-15
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '043'
+    description: Balboas Panameñas
+    valid_from: 2009-04-15
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '044'
+    description: Córdoba Nicaragüense
+    valid_from: 2009-04-15
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '045'
+    description: Dirham Marroquí
+    valid_from: 2009-04-15
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '046'
+    description: Libra Egipcia
+    valid_from: 2009-04-15
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '047'
+    description: Riyal Saudita
+    valid_from: 2009-04-15
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '061'
+    description: Zloty Polaco
+    valid_from: 2009-04-15
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '062'
+    description: Rupia Hindú
+    valid_from: 2009-04-15
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '063'
+    description: Lempira Hondureña
+    valid_from: 2009-04-15
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '064'
+    description: Yuan (Rep. Pop. China)
+    valid_from: 2009-04-15
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: 009
+    description: Franco Suizo
+    valid_from: 2009-11-10
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: '041'
+    description: Derechos Especiales de Giro
+    valid_from: 2010-01-25
+    valid_to: null
+- model: afip.currencytype
+  fields:
+    code: 049
+    description: Gramos de Oro Fino
+    valid_from: 2010-01-25
+    valid_to: null

--- a/django_afip/fixtures/documenttype.yaml
+++ b/django_afip/fixtures/documenttype.yaml
@@ -1,0 +1,216 @@
+- model: afip.documenttype
+  fields:
+    code: '80'
+    description: CUIT
+    valid_from: 2008-07-25
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '86'
+    description: CUIL
+    valid_from: 2008-07-25
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '87'
+    description: CDI
+    valid_from: 2008-07-25
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '89'
+    description: LE
+    valid_from: 2008-07-25
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '90'
+    description: LC
+    valid_from: 2008-07-25
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '91'
+    description: CI Extranjera
+    valid_from: 2008-07-25
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '92'
+    description: en trámite
+    valid_from: 2008-07-25
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '93'
+    description: Acta Nacimiento
+    valid_from: 2008-07-25
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '95'
+    description: CI Bs. As. RNP
+    valid_from: 2008-07-25
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '96'
+    description: DNI
+    valid_from: 2008-07-25
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '94'
+    description: Pasaporte
+    valid_from: 2008-07-25
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '0'
+    description: CI Policía Federal
+    valid_from: 2008-07-25
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '1'
+    description: CI Buenos Aires
+    valid_from: 2008-07-25
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '2'
+    description: CI Catamarca
+    valid_from: 2008-07-25
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '3'
+    description: CI Córdoba
+    valid_from: 2008-07-25
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '4'
+    description: CI Corrientes
+    valid_from: 2008-07-28
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '5'
+    description: CI Entre Ríos
+    valid_from: 2008-07-28
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '6'
+    description: CI Jujuy
+    valid_from: 2008-07-28
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '7'
+    description: CI Mendoza
+    valid_from: 2008-07-28
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '8'
+    description: CI La Rioja
+    valid_from: 2008-07-28
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '9'
+    description: CI Salta
+    valid_from: 2008-07-28
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '10'
+    description: CI San Juan
+    valid_from: 2008-07-28
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '11'
+    description: CI San Luis
+    valid_from: 2008-07-28
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '12'
+    description: CI Santa Fe
+    valid_from: 2008-07-28
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '13'
+    description: CI Santiago del Estero
+    valid_from: 2008-07-28
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '14'
+    description: CI Tucumán
+    valid_from: 2008-07-28
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '16'
+    description: CI Chaco
+    valid_from: 2008-07-28
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '17'
+    description: CI Chubut
+    valid_from: 2008-07-28
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '18'
+    description: CI Formosa
+    valid_from: 2008-07-28
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '19'
+    description: CI Misiones
+    valid_from: 2008-07-28
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '20'
+    description: CI Neuquén
+    valid_from: 2008-07-28
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '21'
+    description: CI La Pampa
+    valid_from: 2008-07-28
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '22'
+    description: CI Río Negro
+    valid_from: 2008-07-28
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '23'
+    description: CI Santa Cruz
+    valid_from: 2008-07-28
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '24'
+    description: CI Tierra del Fuego
+    valid_from: 2008-07-28
+    valid_to: null
+- model: afip.documenttype
+  fields:
+    code: '99'
+    description: Doc. (Otro)
+    valid_from: 2008-07-28
+    valid_to: null

--- a/django_afip/fixtures/receipttype.yaml
+++ b/django_afip/fixtures/receipttype.yaml
@@ -1,0 +1,216 @@
+- model: afip.receipttype
+  fields:
+    code: '1'
+    description: Factura A
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '2'
+    description: Nota de Débito A
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '3'
+    description: Nota de Crédito A
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '6'
+    description: Factura B
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '7'
+    description: Nota de Débito B
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '8'
+    description: Nota de Crédito B
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '4'
+    description: Recibos A
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '5'
+    description: Notas de Venta al contado A
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '9'
+    description: Recibos B
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '10'
+    description: Notas de Venta al contado B
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '63'
+    description: Liquidacion A
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '64'
+    description: Liquidacion B
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '34'
+    description: Cbtes. A del Anexo I, Apartado A,inc.f),R.G.Nro. 1415
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '35'
+    description: Cbtes. B del Anexo I,Apartado A,inc. f),R.G. Nro. 1415
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '39'
+    description: Otros comprobantes A que cumplan con R.G.Nro. 1415
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '40'
+    description: Otros comprobantes B que cumplan con R.G.Nro. 1415
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '60'
+    description: Cta de Vta y Liquido prod. A
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '61'
+    description: Cta de Vta y Liquido prod. B
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '11'
+    description: Factura C
+    valid_from: 2011-03-30
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '12'
+    description: Nota de Débito C
+    valid_from: 2011-03-30
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '13'
+    description: Nota de Crédito C
+    valid_from: 2011-03-30
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '15'
+    description: Recibo C
+    valid_from: 2011-03-30
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '49'
+    description: Comprobante de Compra de Bienes Usados a Consumidor Final
+    valid_from: 2013-04-01
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '51'
+    description: Factura M
+    valid_from: 2015-05-22
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '52'
+    description: Nota de Débito M
+    valid_from: 2015-05-22
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '53'
+    description: Nota de Crédito M
+    valid_from: 2015-05-22
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '54'
+    description: Recibo M
+    valid_from: 2015-05-22
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '201'
+    description: Factura de Crédito electrónica MiPyMEs (FCE) A
+    valid_from: 2018-12-26
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '202'
+    description: Nota de Débito electrónica MiPyMEs (FCE) A
+    valid_from: 2018-12-26
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '203'
+    description: Nota de Crédito electrónica MiPyMEs (FCE) A
+    valid_from: 2018-12-26
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '206'
+    description: Factura de Crédito electrónica MiPyMEs (FCE) B
+    valid_from: 2018-12-26
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '207'
+    description: Nota de Débito electrónica MiPyMEs (FCE) B
+    valid_from: 2018-12-26
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '208'
+    description: Nota de Crédito electrónica MiPyMEs (FCE) B
+    valid_from: 2018-12-26
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '211'
+    description: Factura de Crédito electrónica MiPyMEs (FCE) C
+    valid_from: 2018-12-26
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '212'
+    description: Nota de Débito electrónica MiPyMEs (FCE) C
+    valid_from: 2018-12-26
+    valid_to: null
+- model: afip.receipttype
+  fields:
+    code: '213'
+    description: Nota de Crédito electrónica MiPyMEs (FCE) C
+    valid_from: 2018-12-26
+    valid_to: null

--- a/django_afip/fixtures/taxtype.yaml
+++ b/django_afip/fixtures/taxtype.yaml
@@ -1,0 +1,66 @@
+- model: afip.taxtype
+  fields:
+    code: '1'
+    description: Impuestos nacionales
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.taxtype
+  fields:
+    code: '2'
+    description: Impuestos provinciales
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.taxtype
+  fields:
+    code: '3'
+    description: Impuestos municipales
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.taxtype
+  fields:
+    code: '4'
+    description: Impuestos Internos
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.taxtype
+  fields:
+    code: '99'
+    description: Otro
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.taxtype
+  fields:
+    code: '5'
+    description: IIBB
+    valid_from: 2017-07-19
+    valid_to: null
+- model: afip.taxtype
+  fields:
+    code: '6'
+    description: Percepción de IVA
+    valid_from: 2017-07-19
+    valid_to: null
+- model: afip.taxtype
+  fields:
+    code: '7'
+    description: Percepción de IIBB
+    valid_from: 2017-07-19
+    valid_to: null
+- model: afip.taxtype
+  fields:
+    code: '8'
+    description: Percepciones por Impuestos Municipales
+    valid_from: 2017-07-19
+    valid_to: null
+- model: afip.taxtype
+  fields:
+    code: '9'
+    description: Otras Percepciones
+    valid_from: 2017-07-19
+    valid_to: null
+- model: afip.taxtype
+  fields:
+    code: '13'
+    description: Percepción de IVA a no Categorizado
+    valid_from: 2017-07-19
+    valid_to: null

--- a/django_afip/fixtures/vattype.yaml
+++ b/django_afip/fixtures/vattype.yaml
@@ -1,0 +1,36 @@
+- model: afip.vattype
+  fields:
+    code: '3'
+    description: 0%
+    valid_from: 2009-02-20
+    valid_to: null
+- model: afip.vattype
+  fields:
+    code: '4'
+    description: 10.5%
+    valid_from: 2009-02-20
+    valid_to: null
+- model: afip.vattype
+  fields:
+    code: '5'
+    description: 21%
+    valid_from: 2009-02-20
+    valid_to: null
+- model: afip.vattype
+  fields:
+    code: '6'
+    description: 27%
+    valid_from: 2009-02-20
+    valid_to: null
+- model: afip.vattype
+  fields:
+    code: '8'
+    description: 5%
+    valid_from: 2014-10-20
+    valid_to: null
+- model: afip.vattype
+  fields:
+    code: '9'
+    description: 2.5%
+    valid_from: 2014-10-20
+    valid_to: null

--- a/django_afip/management/commands/afipmetadata.py
+++ b/django_afip/management/commands/afipmetadata.py
@@ -5,8 +5,8 @@ from django_afip import models
 
 
 class Command(BaseCommand):
-    help = _("Fetches required AFIP metadata and stores it locally.")
+    help = _("Loads fixtures with metadata from AFIP.")
     requires_migrations_checks = True
 
     def handle(self, *args, **options):
-        models.populate_all()
+        models.load_metadata()

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 
 import pytz
 from django.conf import settings
+from django.core import management
 from django.core.files import File
 from django.db import models
 from django.db.models import Count
@@ -61,14 +62,12 @@ CLIENT_VAT_CONDITIONS = (
 )
 
 
-def populate_all():
-    """Fetch and store all metadata from the AFIP."""
-    ReceiptType.objects.populate()
-    ConceptType.objects.populate()
-    DocumentType.objects.populate()
-    VatType.objects.populate()
-    TaxType.objects.populate()
-    CurrencyType.objects.populate()
+def load_metadata():
+    """Loads metadata from fixtures into the database."""
+
+    for model in GenericAfipType.SUBCLASSES:
+        label = model._meta.label.split(".")[1].lower()
+        management.call_command("loaddata", label, app="afip")
 
 
 def check_response(response):
@@ -123,8 +122,10 @@ class GenericAfipTypeManager(models.Manager):
         self.__type_name = type_name
 
     def populate(self, ticket=None):
-        """
-        Populate the database with types retrieved from the AFIP.
+        """Fetch and save data for this model from AFIP's WS.
+
+        Direct usage of this method is discouraged, use
+        :func:`~.models.load_metadata` instead.
 
         If no ticket is provided, the most recent available one will be used.
         """

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -141,6 +141,12 @@ class GenericAfipTypeManager(models.Manager):
                 valid_to=parsers.parse_date(result.FchHasta),
             )
 
+    def get_by_natural_key(self, code):
+        return self.get(code=code)
+
+    def exists_by_natural_key(self, code):
+        return self.filter(code=code).exists()
+
 
 class GenericAfipType(models.Model):
     """An abstract class for several of AFIP's metadata types."""
@@ -163,6 +169,9 @@ class GenericAfipType(models.Model):
         null=True,
         blank=True,
     )
+
+    def natural_key(self):
+        return (self.code,)
 
     def __str__(self):
         return self.description

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -9,6 +9,8 @@ from datetime import timedelta
 from datetime import timezone
 from io import BytesIO
 from tempfile import NamedTemporaryFile
+from typing import List
+from typing import Type
 from uuid import uuid4
 
 import pytz
@@ -149,7 +151,18 @@ class GenericAfipTypeManager(models.Manager):
 
 
 class GenericAfipType(models.Model):
-    """An abstract class for several of AFIP's metadata types."""
+    """An abstract class for several of AFIP's metadata types.
+
+    You should not use this class directly, only subclasses of it. You should
+    not create subclasses of this model unless you really know what you're doing.
+    """
+
+    SUBCLASSES: List[Type] = []
+
+    def __init_subclass__(cls, **kwargs):
+        """Keeps a registry of known subclasses."""
+        super().__init_subclass__(**kwargs)
+        GenericAfipType.SUBCLASSES.append(cls)
 
     code = models.CharField(
         _("code"),

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -36,11 +36,12 @@ unless you intend to generate PDFs for receipts.
 Metadata models
 ---------------
 
-These models represent metadata like currency types or document types. Their
-tables should be populated from AFIP's webservices, using the ``afipmetadata``
-command.
+These models represent metadata like currency types or document types.
 
-.. autofunction:: django_afip.models.populate_all
+You should make sure you populate these tables either via the ``afipmetadata``
+command, or the ``load_metadata`` function:
+
+.. autofunction:: django_afip.models.load_metadata
 
 .. autoclass:: django_afip.models.ConceptType
     :members:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -60,21 +60,22 @@ Once you have created a :class:`~.TaxPayer`, you'll need its points of sales. Th
 again, can be done via the admin by selecting "fetch points of sales'. You may
 also do this programatically via :meth:`~.TaxPayer.fetch_points_of_sales`.
 
-Metadata populuation
-~~~~~~~~~~~~~~~~~~~~
+Loading Metadata
+~~~~~~~~~~~~~~~~
 
 You'll also need to pre-populate certain models with AFIP-defined metadata
 (:class:`~.ReceiptType`, :class:`~.DocumentType` and a few others).
 
-Rather than include fixtures which require updating over time, we fetch this
-information from AFIP's web services via an included django management command.
-This command is idempotent, and running it more than once will not create any
-duplicate data. To fetch all metadata, simply run::
+This package includes fixtures with this metadata, which can be imported by
+running::
 
     python manage.py afipmetadata
 
-This metadata can also be downloaded programatically, by using the function
-:func:`~.models.populate_all`.
+This command is idempotent, and running it more than once will not create any
+duplicate data.
+
+This metadata can also be imported programatically, by using the function
+:func:`~.models.load_metadata`. This can be useful for your unit tests.
 
 You are now ready to start creating and validating receipts. While you may do
 this via the admin as well, you probably want to do this programmatically or via
@@ -111,7 +112,7 @@ above steps programatically:
     taxpayer.save()
 
     # Load all metadata:
-    models.populate_all()
+    models.load_metadata()
 
     # Get the TaxPayer's Point of Sales:
     taxpayer.fetch_points_of_sales()

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -77,6 +77,13 @@ duplicate data.
 This metadata can also be imported programatically, by using the function
 :func:`~.models.load_metadata`. This can be useful for your unit tests.
 
+.. hint::
+
+    Since it's safe to run ``load_metadata`` as many times as you wish, it may
+    be feasible to run this right after you run your migrations in your deploy
+    script. This will make sure you always have all metadata loaded in all
+    environments.
+
 You are now ready to start creating and validating receipts. While you may do
 this via the admin as well, you probably want to do this programmatically or via
 some custom view.

--- a/scripts/dump_metadata.py
+++ b/scripts/dump_metadata.py
@@ -1,0 +1,33 @@
+"""Script used to generate AFIP metadata fixtures.
+
+This script is used to generate the fixtures with AFIP metadata. It is only used to
+BUILD django_afip, and should not be used directly by third-party apps.
+"""
+import django
+from django.core import management
+
+
+if __name__ == "__main__":
+    # Set up django...
+    django.setup()
+    management.call_command("migrate")
+
+    from django_afip.factories import TaxPayerFactory
+    from django_afip.models import GenericAfipType
+
+    # Initialise (uses test credentials).
+    TaxPayerFactory()
+
+    # Fetch and dump data:
+    for model in GenericAfipType.SUBCLASSES:
+        model.objects.populate()
+
+        label = model._meta.label.split(".")[1].lower()
+
+        management.call_command(
+            "dumpdata",
+            f"afip.{label}",
+            format="yaml",
+            use_natural_primary_keys=True,
+            output=f"django_afip/fixtures/{label}.yaml",
+        )

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         "wheel>=0.24.0",
         "zeep>=1.1.0,<4.0.0",
         "qrcode[pil]>=6.1,<7.0",
+        "pyyaml>=^5.3.1,<6.0.0",
     ],
     extras_require={
         "docs": ["Sphinx", "sphinx-autobuild"],

--- a/testapp/testapp/testmain/tests/test_management.py
+++ b/testapp/testapp/testmain/tests/test_management.py
@@ -1,0 +1,17 @@
+import pytest
+from django.core import management
+
+from django_afip.models import GenericAfipType
+
+
+@pytest.mark.django_db
+def test_afip_metadata_command():
+    assert len(GenericAfipType.SUBCLASSES) == 6
+
+    for model in GenericAfipType.SUBCLASSES:
+        assert model.objects.count() == 0
+
+    management.call_command("afipmetadata")
+
+    for model in GenericAfipType.SUBCLASSES:
+        assert model.objects.count() > 0

--- a/testapp/testapp/testmain/tests/test_webservices.py
+++ b/testapp/testapp/testmain/tests/test_webservices.py
@@ -34,7 +34,7 @@ class AuthTicketTest(TestCase):
             # Note: AFIP apparently edited this message and added a typo:
             "ValidacionDeToken: No apareci[oó] CUIT en lista de relaciones:",
         ):
-            models.populate_all()
+            taxpayer.fetch_points_of_sales()
 
     def test_bogus_certificate_exception(self):
         """Test that using a junk ceritificates raises as expected."""

--- a/testapp/testapp/testmain/tests/testcases.py
+++ b/testapp/testapp/testmain/tests/testcases.py
@@ -33,6 +33,6 @@ class PopulatedLiveAfipTestCase(LiveAfipTestCase):
     def setUp(self):
         """Populate AFIP metadata and create a TaxPayer and PointOfSales."""
         super().setUp()
-        models.populate_all()
+        models.load_metadata()
         taxpayer = models.TaxPayer.objects.first()
         taxpayer.fetch_points_of_sales()

--- a/tox.ini
+++ b/tox.ini
@@ -33,3 +33,9 @@ commands =
   make -C docs html
 whitelist_externals =
   make
+
+[testenv:fixtures]
+commands = python scripts/dump_metadata.py
+setenv =
+  PYTHONPATH={toxinidir}/testapp:{toxinidir}
+  DJANGO_SETTINGS_MODULE=testapp.settings


### PR DESCRIPTION
The initial implementation of this library included a [management command](https://django-afip.readthedocs.io/en/v7.1.2/usage.html#metadata-populuation) to fetch all metadata from AFIP's servers.

This fetched things like currency types, document types, etc. It sounded like a great idea, and would have made developer's life much easier each time AFIP changed these.

Experience and time have proven the contrary: AFIP seldom changes this data, and the management command confuses developers and adds complexity for setting up new applications and even new environments. The most annoying part, is needing a TaxPayer _before_ fetching the data, which means that an empty environment can't have metadata.

Fixes  #59