### PR TITLE
Revalidar receipt

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ acá.
 * Soporte para Zeep ~4.0.0.
 * Soporte para Django 3.2.
 * La [mayoría de la] documentación ahora está traducida.
-* Se implementa ``Receipt.revalidate()``. Provee un mecanismo de revalidacion
+* Se implementa :meth:`~.Receipt.revalidate`. Provee un mecanismo de revalidacion
   de un comprobante para completar datos faltandes referentes a la validacion del mismo.
 
 8.0.4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ acá.
 * Soporte para Zeep ~4.0.0.
 * Soporte para Django 3.2.
 * La [mayoría de la] documentación ahora está traducida.
-* Se implementa ``Receipt.revalidate()``. Provee un mecanismo de revalidacion 
+* Se implementa ``Receipt.revalidate()``. Provee un mecanismo de revalidacion
   de un comprobante para completar datos faltandes referentes a la validacion del mismo.
 
 8.0.4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ acá.
 * Soporte para Zeep ~4.0.0.
 * Soporte para Django 3.2.
 * La [mayoría de la] documentación ahora está traducida.
+* Se implementa ``Receipt.revalidate()``. Provee un mecanismo de revalidacion 
+  de un comprobante para completar datos faltandes referentes a la validacion del mismo.
 
 8.0.4
 -----

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -31,7 +31,6 @@ from . import crypto
 from . import exceptions
 from . import parsers
 from . import serializers
-from .exceptions import AfipException
 
 logger = logging.getLogger(__name__)
 TZ_AR = pytz.timezone(pytz.country_timezones["ar"][0])
@@ -904,7 +903,7 @@ class ReceiptManager(models.Manager):
             try:
                 check_response(response_xml)
                 return response_xml.ResultGet
-            except AfipException:
+            except exceptions.AfipException:
                 return None
         return None
 

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -1141,9 +1141,7 @@ class Receipt(models.Model):
                     result=receipt_data.Resultado,
                     cae=receipt_data.CodAutorizacion,
                     cae_expiration=parsers.parse_date(receipt_data.FchVto),
-                    receipt=self.get(
-                        receipt_number=receipt_data.CbteDesde,
-                    ),
+                    receipt=self,
                     processed_date=parsers.parse_datetime(
                         receipt_data.FchProceso,
                     ),

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -1148,7 +1148,7 @@ class Receipt(models.Model):
                 )
                 if receipt_data.Observaciones:
                     for obs in receipt_data.Observaciones.Obs:
-                        observation = Observation.objects.create(
+                        observation = Observation.objects.get_or_create(
                             code=obs.Code,
                             message=obs.Msg,
                         )

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -1125,11 +1125,14 @@ class Receipt(models.Model):
 
     def revalidate(self) -> Optional["ReceiptValidation"]:
         """Revalidate this receipt.
-        
-        Fetches data of a validated receipt from AFIP's servers. If the receipt exists
-        a ``ReceiptValidation`` instance is created and returned, otherwise, returns ``None``.
-        If there is already a ``ReceiptValidation`` for this instance, returns ``self.validation``.
-        This should be used for verification purpose, here's a list of some use cases:
+
+        Fetches data of a validated receipt from AFIP's servers.
+        If the receipt exists a ``ReceiptValidation`` instance is
+        created and returned, otherwise, returns ``None``.
+        If there is already a ``ReceiptValidation`` for this instance,
+        returns ``self.validation``.
+        This should be used for verification purpose, here's a list of
+        some use cases:
          - Incomplete validation process
          - Fetch CAE data from AFIP's servers
         """

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -1128,8 +1128,7 @@ class Receipt(models.Model):
         
         Fetches data of a validated receipt from AFIP's servers. If the receipt exists
         a ``ReceiptValidation`` instance is created and returned, otherwise, returns ``None``.
-        If there is a ReceiptValidation for this instance, returns ``self.validation``.
-        
+        If there is already a ``ReceiptValidation`` for this instance, returns ``self.validation``.
         This should be used for verification purpose, here's a list of some use cases:
          - Incomplete validation process
          - Fetch CAE data from AFIP's servers

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -8,6 +8,7 @@ from datetime import timezone
 from io import BytesIO
 from tempfile import NamedTemporaryFile
 from typing import List
+from typing import Optional
 from typing import Type
 from uuid import uuid4
 
@@ -30,6 +31,7 @@ from . import crypto
 from . import exceptions
 from . import parsers
 from . import serializers
+from .exceptions import AfipException
 
 logger = logging.getLogger(__name__)
 TZ_AR = pytz.timezone(pytz.country_timezones["ar"][0])
@@ -889,18 +891,22 @@ class ReceiptManager(models.Manager):
 
     def fetch_receipt_data(self, receipt_type, receipt_number, point_of_sales):
         """Returns receipt related data"""
-        client = clients.get_client("wsfe", point_of_sales.owner.is_sandboxed)
-        response_xml = client.service.FECompConsultar(
-            serializers.serialize_ticket(
-                point_of_sales.owner.get_or_create_ticket("wsfe")
-            ),
-            serializers.serialize_receipt_data(
-                receipt_type, receipt_number, point_of_sales.number
-            ),
-        )
-        check_response(response_xml)
-
-        return response_xml.ResultGet
+        if receipt_number:
+            client = clients.get_client("wsfe", point_of_sales.owner.is_sandboxed)
+            response_xml = client.service.FECompConsultar(
+                serializers.serialize_ticket(
+                    point_of_sales.owner.get_or_create_ticket("wsfe")
+                ),
+                serializers.serialize_receipt_data(
+                    receipt_type, receipt_number, point_of_sales.number
+                ),
+            )
+            try:
+                check_response(response_xml)
+                return response_xml.ResultGet
+            except AfipException:
+                return None
+        return None
 
     def get_queryset(self):
         return ReceiptQuerySet(self.model, using=self._db).select_related(
@@ -1115,6 +1121,43 @@ class Receipt(models.Model):
         if raise_ and rv:
             raise exceptions.ValidationError(rv[0])
         return rv
+
+    def revalidate(self) -> Optional["ReceiptValidation"]:
+        """Revalidate this receipt.
+        This should be used for verification purpose, here's a list of some use cases:
+         - Incomplete validation process
+         - Fetch CAE data from AFIP's servers
+        """
+        # This may avoid unnecessary revalidation
+        if self.is_validated:
+            return self.validation
+
+        receipt_data = Receipt.objects.fetch_receipt_data(
+            self.receipt_type.code, self.receipt_number, self.point_of_sales
+        )
+
+        if receipt_data:
+            if receipt_data.Resultado == ReceiptValidation.RESULT_APPROVED:
+                validation = ReceiptValidation.objects.create(
+                    result=receipt_data.Resultado,
+                    cae=receipt_data.CodAutorizacion,
+                    cae_expiration=parsers.parse_date(receipt_data.FchVto),
+                    receipt=self.get(
+                        receipt_number=receipt_data.CbteDesde,
+                    ),
+                    processed_date=parsers.parse_datetime(
+                        receipt_data.FchProceso,
+                    ),
+                )
+                if receipt_data.Observaciones:
+                    for obs in receipt_data.Observaciones.Obs:
+                        observation = Observation.objects.create(
+                            code=obs.Code,
+                            message=obs.Msg,
+                        )
+                    validation.observations.add(observation)
+                return validation
+        return None
 
     def __repr__(self):
         return "<Receipt {}: {} {} for {}>".format(

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -1125,6 +1125,11 @@ class Receipt(models.Model):
 
     def revalidate(self) -> Optional["ReceiptValidation"]:
         """Revalidate this receipt.
+        
+        Fetches data of a validated receipt from AFIP's servers. If the receipt exists
+        a ``ReceiptValidation`` instance is created and returned, otherwise, returns ``None``.
+        If there is a ReceiptValidation for this instance, returns ``self.validation``.
+        
         This should be used for verification purpose, here's a list of some use cases:
          - Incomplete validation process
          - Fetch CAE data from AFIP's servers

--- a/testapp/testapp/testmain/tests/test_models.py
+++ b/testapp/testapp/testmain/tests/test_models.py
@@ -167,7 +167,11 @@ class ReceitpSuccessfulRevalidationTestCase(PopulatedLiveAfipTestCase):
 
         receipt.validation.delete()
 
+        receipt.refresh_from_db()
+        assert not receipt.is_validated()
+
         validation = receipt.revalidate()
+
         assert validation is not None
         assert validation.receipt == receipt
         assert old_cae == validation.cae
@@ -192,8 +196,6 @@ class ReceitpFailedRevalidationTestCase(PopulatedLiveAfipTestCase):
         receipt.refresh_from_db()
 
         validation = receipt.revalidate()
-
-        receipt.refresh_from_db()
 
         assert validation is None
 

--- a/testapp/testapp/testmain/tests/test_models.py
+++ b/testapp/testapp/testmain/tests/test_models.py
@@ -168,7 +168,7 @@ class ReceitpSuccessfulRevalidationTestCase(PopulatedLiveAfipTestCase):
         receipt.validation.delete()
 
         receipt.refresh_from_db()
-        assert not receipt.is_validated()
+        assert not receipt.is_validated
 
         validation = receipt.revalidate()
 

--- a/testapp/testapp/testmain/tests/test_models.py
+++ b/testapp/testapp/testmain/tests/test_models.py
@@ -193,6 +193,8 @@ class ReceitpFailedRevalidationTestCase(PopulatedLiveAfipTestCase):
 
         validation = receipt.revalidate()
 
+        receipt.refresh_from_db()
+
         assert validation is None
 
     def test_receipt_revalidate_without_receipt_number(self):

--- a/testapp/testapp/testmain/tests/test_models.py
+++ b/testapp/testapp/testmain/tests/test_models.py
@@ -259,6 +259,17 @@ def test_default_currency_multieple_currencies():
     assert receipt.currency != c3
 
 
+@pytest.mark.django_db
+def test_revalidation_validated_receipt():
+    """Test revalidation process of a validated receipt."""
+    receipt_validation = factories.ReceiptValidationFactory()
+
+    revalidation = receipt_validation.receipt.revalidate()
+
+    assert revalidation is not None
+    assert revalidation == receipt_validation
+
+
 class ReceiptTotalVatTestCase(TestCase):
     def test_no_vat(self):
         receipt = factories.ReceiptFactory()


### PR DESCRIPTION
Se implementa `revalidate()` para dar soporte al issue https://github.com/WhyNotHugo/django-afip/issues/92. Ademas se contemplan los 3 casos de prueba descriptos.

**Aclaraciones**

- Se utilizo un procedimiento similar al `_validate()` para registrar las ReceiptValidations (cambian algunos nombres de atributos)
- FECompConsultar da error si el comprobante no existe en AFIP, por lo que tuve que capturar la excepcion (abierto a sugerencias)
