### PR TITLE
Changed value used to check if fetched points of sales are blocked

### DIFF
--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -483,7 +483,7 @@ class TaxPayer(models.Model):
                     owner=self,
                     defaults={
                         "issuance_type": pos_data.EmisionTipo,
-                        "blocked": pos_data.Bloqueado == "N",
+                        "blocked": pos_data.Bloqueado == "S",
                         "drop_date": parsers.parse_date(pos_data.FchBaja),
                     },
                 )


### PR DESCRIPTION
```bloqueado``` field in ```PointOfSale``` model it's a merely informative field, it Indicates whether the point of sale is blocked or not. If this situation occurs, you should enter the ABM of points of sale to regularize the situation, the possible values returned are `S` that stands for `SI` meaning that the `POS` is blocked or `N` that stands for `NO` meaning that the `POS` is available.
So the value used to check the AFIP pos_data.Bloqueado result has been changed from N to S, this will allow us to better identify if the POS if blocked or not.