### PR TITLE
Increase AuthTicket service field max_length from 6 to 34

### DIFF
--- a/django_afip/migrations/0010_alter_authticket_service.py
+++ b/django_afip/migrations/0010_alter_authticket_service.py
@@ -5,13 +5,17 @@ from django.db import models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('afip', '0009_alter_pointofsales_issuance_type'),
+        ("afip", "0009_alter_pointofsales_issuance_type"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='authticket',
-            name='service',
-            field=models.CharField(help_text='Service for which this ticket has been authorized.', max_length=34, verbose_name='service'),
+            model_name="authticket",
+            name="service",
+            field=models.CharField(
+                help_text="Service for which this ticket has been authorized.",
+                max_length=34,
+                verbose_name="service",
+            ),
         ),
     ]

--- a/django_afip/migrations/0010_alter_authticket_service.py
+++ b/django_afip/migrations/0010_alter_authticket_service.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('afip', '0009_alter_pointofsales_issuance_type'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='authticket',
+            name='service',
+            field=models.CharField(help_text='Service for which this ticket has been authorized.', max_length=34, verbose_name='service'),
+        ),
+    ]

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -710,7 +710,7 @@ class AuthTicket(models.Model):
     )
     service = models.CharField(
         _("service"),
-        max_length=6,
+        max_length=34,
         help_text=_("Service for which this ticket has been authorized."),
     )
 


### PR DESCRIPTION
This commit will increase the `max_length` in the field `service `of `AuthTicket` model from 6 to 34 to allow the longest service provided by afip (`consultaautorizacioneselectronicas`), for those who are working with another services than `wsfe` or `wsaa`.
closes: #146 