### PR TITLE
Support for AFIP Optionals in Receipts (FCE)

### DIFF
--- a/django_afip/factories.py
+++ b/django_afip/factories.py
@@ -149,6 +149,33 @@ class ReceiptWithVatAndTaxFactory(ReceiptFactory):
         TaxFactory(tax_type__code=3, receipt=obj)
 
 
+class ReceiptFCEAWithVatAndTaxFactory(ReceiptFactory):
+    """Receipt FCEA with a valid Vat and Tax, ready to validate."""
+
+    document_number = 20111111112
+    point_of_sales = LazyFunction(lambda: models.PointOfSales.objects.first())
+    receipt_type = SubFactory(ReceiptTypeFactory, code=201)
+    document_type = SubFactory(DocumentTypeFactory, code=80)
+    expiration_date = LazyFunction(date.today)
+
+    @post_generation
+    def post(obj: models.Receipt, create, extracted, **kwargs):
+        VatFactory(vat_type__code=5, receipt=obj)
+        TaxFactory(tax_type__code=3, receipt=obj)
+
+
+class ReceiptFCEAWithVatTaxAndOptionalsFactory(ReceiptFCEAWithVatAndTaxFactory):
+    """Receipt FCEA with a valid Vat, Tax and Optionals, ready to validate."""
+
+    @post_generation
+    def post(obj: models.Receipt, create, extracted, **kwargs):
+        VatFactory(vat_type__code=5, receipt=obj)
+        TaxFactory(tax_type__code=3, receipt=obj)
+        OptionalFactory(optional_type__code=2101, receipt=obj)
+        # Value SCA stands for TRANSFERENCIA AL SISTEMA DE CIRCULACION ABIERTA
+        OptionalFactory(optional_type__code=27, receipt=obj, value='SCA')
+
+
 class ReceiptWithInconsistentVatAndTaxFactory(ReceiptWithVatAndTaxFactory):
     """Receipt with a valid Vat and Tax, ready to validate."""
 
@@ -222,6 +249,14 @@ class TaxTypeFactory(GenericAfipTypeFactory):
         model = models.TaxType
 
 
+class OptionalTypeFactory(GenericAfipTypeFactory):
+    class Meta:
+        model = models.OptionalType
+
+    code = 2101
+    description = "Excepcion computo IVA Credito Fiscal"
+
+
 class VatFactory(DjangoModelFactory):
     class Meta:
         model = models.Vat
@@ -239,8 +274,19 @@ class TaxFactory(DjangoModelFactory):
     aliquot = 9
     amount = 9
     base_amount = 100
+    description = 'Test description'
     receipt = SubFactory(ReceiptFactory)
     tax_type = SubFactory(TaxTypeFactory)
+
+
+class OptionalFactory(DjangoModelFactory):
+    class Meta:
+        model = models.Optional
+
+    # This value represent a valid CBU
+    value = '1064169911100089878669'
+    receipt = SubFactory(ReceiptFactory)
+    optional_type = SubFactory(OptionalTypeFactory)
 
 
 class ReceiptEntryFactory(DjangoModelFactory):

--- a/django_afip/fixtures/optionaltype.yaml
+++ b/django_afip/fixtures/optionaltype.yaml
@@ -1,144 +1,144 @@
 - model: afip.optionaltype
   fields:
     code: '2'
-    description: RG Empresas Promovidas - Indentificador de proyecto vinculado a Regimen de Promocion Industrial
-    valid_from: 2010-09-17
+    description: RG Empresas Promovidas - Indentificador de proyecto vinculado a Régimen de Promoción Industrial
+    valid_from: '2010-09-17'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '91'
-    description: RG Bienes Usados 3411 - Nombre y Apellido o Denominacion del vendedor del bien usado
-    valid_from: 2010-09-17
+    description: RG Bienes Usados 3411 - Nombre y Apellido o Denominación del vendedor del bien usado.
+    valid_from: '2013-04-01'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '92'
     description: RG Bienes Usados 3411 - Nacionalidad del vendedor del bien usado.
-    valid_from: 2010-09-17
+    valid_from: '2013-04-01'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '93'
     description: RG Bienes Usados 3411 - Domicilio del vendedor del bien usado.
-    valid_from: 2010-09-17
+    valid_from: '2013-04-01'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '5'
     description: Excepcion computo IVA Credito Fiscal
-    valid_from: 2010-09-17
+    valid_from: '2014-10-16'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '61'
     description: RG 3668 Impuesto al Valor Agregado - Art.12 IVA Firmante Doc Tipo
-    valid_from: 2010-09-17
+    valid_from: '2014-10-16'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '62'
     description: RG 3668 Impuesto al Valor Agregado - Art.12 IVA Firmante Doc Nro
-    valid_from: 2010-09-17
+    valid_from: '2014-10-16'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '7'
     description: RG 3668 Impuesto al Valor Agregado - Art.12 IVA Carácter del Firmante
-    valid_from: 2010-09-17
+    valid_from: '2014-10-16'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '10'
     description: RG 3.368 Establecimientos de educación pública de gestión privada - Actividad Comprendida
-    valid_from: 2010-09-17
+    valid_from: '2015-06-05'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '1011'
     description: RG 3.368 Establecimientos de educación pública de gestión privada - Tipo de Documento
-    valid_from: 2010-09-17
+    valid_from: '2015-06-05'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '1012'
     description: RG 3.368 Establecimientos de educación pública de gestión privada - Número de Documento
-    valid_from: 2010-09-17
+    valid_from: '2015-06-05'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '11'
     description: RG 2.820 Operaciones económicas vinculadas con bienes inmuebles - Actividad Comprendida
-    valid_from: 2010-09-17
+    valid_from: '2015-06-05'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '12'
     description: RG 3.687 Locación temporaria de inmuebles con fines turísticos - Actividad Comprendida
-    valid_from: 2010-09-17
+    valid_from: '2015-06-05'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '13'
     description: RG 2.863 Representantes de Modelos
-    valid_from: 2010-09-17
+    valid_from: '2016-01-01'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '14'
     description: RG 2.863 Agencias de publicidad
-    valid_from: 2010-09-17
+    valid_from: '2016-01-01'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '15'
-    description: RG 2.863 Personas físicas que desarrollen actividad de modelaje
-    valid_from: 2010-09-17
+    description: RG 2.863 Personas físicas que desarrollen actividad de- modelaje
+    valid_from: '2016-01-01'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '17'
-    description: RG 4004-E Locación de inmuebles destino casa-habitación. Dato 2 (dos) = facturación directa / Dato 1 (uno) = facturación a través de intermediario
-    valid_from: 2010-09-17
+    description: RG 4004-E Locación de inmuebles destino 'casa-habitación'. Dato 2 (dos) = facturación directa / Dato 1 (uno) = facturación a través de intermediario
+    valid_from: '2017-03-09'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '1801'
-    description: RG 4004-E Locación de inmuebles destino casa-habitación. Clave única de Identificación Tributaria (CUIT).
-    valid_from: 2010-09-17
+    description: RG 4004-E Locación de inmuebles destino 'casa-habitación'. Clave única de Identificación Tributaria (CUIT).
+    valid_from: '2017-03-09'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '1802'
-    description: RG 4004-E Locación de inmuebles destino casa-habitación. Apellido y nombres, denominación y/o razón social.
-    valid_from: 2010-09-17
+    description: RG 4004-E Locación de inmuebles destino 'casa-habitación'. Apellido y nombres, denominación y/o razón social.
+    valid_from: '2017-03-09'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '2101'
     description: Factura de Crédito Electrónica MiPyMEs (FCE) - CBU del Emisor
-    valid_from: 2010-09-17
+    valid_from: '2018-12-26'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '2102'
     description: Factura de Crédito Electrónica MiPyMEs (FCE) - Alias del Emisor
-    valid_from: 2010-09-17
+    valid_from: '2018-12-26'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '22'
     description: Factura de Crédito Electrónica MiPyMEs (FCE) - Anulación
-    valid_from: 2010-09-17
+    valid_from: '2018-12-26'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '23'
     description: Factura de Crédito Electrónica MiPyMEs (FCE) - Referencia Comercial
-    valid_from: 2010-09-17
+    valid_from: '2019-03-08'
     valid_to: null
 - model: afip.optionaltype
   fields:
     code: '27'
     description: Factura de Credito Electronica MiPyMEs (FCE) - Transferencia
-    valid_from: 2010-09-17
+    valid_from: '2020-11-26'
     valid_to: null

--- a/django_afip/fixtures/optionaltype.yaml
+++ b/django_afip/fixtures/optionaltype.yaml
@@ -1,0 +1,144 @@
+- model: afip.optionaltype
+  fields:
+    code: '2'
+    description: RG Empresas Promovidas - Indentificador de proyecto vinculado a Regimen de Promocion Industrial
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '91'
+    description: RG Bienes Usados 3411 - Nombre y Apellido o Denominacion del vendedor del bien usado
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '92'
+    description: RG Bienes Usados 3411 - Nacionalidad del vendedor del bien usado.
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '93'
+    description: RG Bienes Usados 3411 - Domicilio del vendedor del bien usado.
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '5'
+    description: Excepcion computo IVA Credito Fiscal
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '61'
+    description: RG 3668 Impuesto al Valor Agregado - Art.12 IVA Firmante Doc Tipo
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '62'
+    description: RG 3668 Impuesto al Valor Agregado - Art.12 IVA Firmante Doc Nro
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '7'
+    description: RG 3668 Impuesto al Valor Agregado - Art.12 IVA Carácter del Firmante
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '10'
+    description: RG 3.368 Establecimientos de educación pública de gestión privada - Actividad Comprendida
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '1011'
+    description: RG 3.368 Establecimientos de educación pública de gestión privada - Tipo de Documento
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '1012'
+    description: RG 3.368 Establecimientos de educación pública de gestión privada - Número de Documento
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '11'
+    description: RG 2.820 Operaciones económicas vinculadas con bienes inmuebles - Actividad Comprendida
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '12'
+    description: RG 3.687 Locación temporaria de inmuebles con fines turísticos - Actividad Comprendida
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '13'
+    description: RG 2.863 Representantes de Modelos
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '14'
+    description: RG 2.863 Agencias de publicidad
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '15'
+    description: RG 2.863 Personas físicas que desarrollen actividad de modelaje
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '17'
+    description: RG 4004-E Locación de inmuebles destino casa-habitación. Dato 2 (dos) = facturación directa / Dato 1 (uno) = facturación a través de intermediario
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '1801'
+    description: RG 4004-E Locación de inmuebles destino casa-habitación. Clave única de Identificación Tributaria (CUIT).
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '1802'
+    description: RG 4004-E Locación de inmuebles destino casa-habitación. Apellido y nombres, denominación y/o razón social.
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '2101'
+    description: Factura de Crédito Electrónica MiPyMEs (FCE) - CBU del Emisor
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '2102'
+    description: Factura de Crédito Electrónica MiPyMEs (FCE) - Alias del Emisor
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '22'
+    description: Factura de Crédito Electrónica MiPyMEs (FCE) - Anulación
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '23'
+    description: Factura de Crédito Electrónica MiPyMEs (FCE) - Referencia Comercial
+    valid_from: 2010-09-17
+    valid_to: null
+- model: afip.optionaltype
+  fields:
+    code: '27'
+    description: Factura de Credito Electronica MiPyMEs (FCE) - Transferencia
+    valid_from: 2010-09-17
+    valid_to: null

--- a/django_afip/migrations/0012_optionaltype_optional_alter_code_in_generics.py
+++ b/django_afip/migrations/0012_optionaltype_optional_alter_code_in_generics.py
@@ -1,0 +1,117 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("afip", "0011_receiptentry_discount_and_more"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="OptionalType",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("code", models.CharField(max_length=3, verbose_name="code")),
+                (
+                    "description",
+                    models.CharField(max_length=250, verbose_name="description"),
+                ),
+                (
+                    "valid_from",
+                    models.DateField(blank=True, null=True, verbose_name="valid from"),
+                ),
+                (
+                    "valid_to",
+                    models.DateField(blank=True, null=True, verbose_name="valid until"),
+                ),
+            ],
+            options={
+                "verbose_name": "optional type",
+                "verbose_name_plural": "optional types",
+            },
+        ),
+        migrations.CreateModel(
+            name="Optional",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "value",
+                    models.CharField(max_length=250, verbose_name="optional value"),
+                ),
+                (
+                    "optional_type",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        to="afip.optionaltype",
+                        verbose_name="optional type",
+                    ),
+                ),
+                (
+                    "receipt",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="optionals",
+                        to="afip.receipt",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "optional",
+                "verbose_name_plural": "optionals",
+            },
+        ),
+        # alter code operations
+        migrations.AlterField(
+            model_name="concepttype",
+            name="code",
+            field=models.CharField(max_length=4, verbose_name="code"),
+        ),
+        migrations.AlterField(
+            model_name="currencytype",
+            name="code",
+            field=models.CharField(max_length=4, verbose_name="code"),
+        ),
+        migrations.AlterField(
+            model_name="documenttype",
+            name="code",
+            field=models.CharField(max_length=4, verbose_name="code"),
+        ),
+        migrations.AlterField(
+            model_name="optionaltype",
+            name="code",
+            field=models.CharField(max_length=4, verbose_name="code"),
+        ),
+        migrations.AlterField(
+            model_name="receipttype",
+            name="code",
+            field=models.CharField(max_length=4, verbose_name="code"),
+        ),
+        migrations.AlterField(
+            model_name="taxtype",
+            name="code",
+            field=models.CharField(max_length=4, verbose_name="code"),
+        ),
+        migrations.AlterField(
+            model_name="vattype",
+            name="code",
+            field=models.CharField(max_length=4, verbose_name="code"),
+        ),
+    ]

--- a/django_afip/migrations/0012_optionaltype_optional_alter_code_in_generics.py
+++ b/django_afip/migrations/0012_optionaltype_optional_alter_code_in_generics.py
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
                         verbose_name="ID",
                     ),
                 ),
-                ("code", models.CharField(max_length=3, verbose_name="code")),
+                ("code", models.CharField(max_length=4, verbose_name="code")),
                 (
                     "description",
                     models.CharField(max_length=250, verbose_name="description"),
@@ -77,41 +77,5 @@ class Migration(migrations.Migration):
                 "verbose_name": "optional",
                 "verbose_name_plural": "optionals",
             },
-        ),
-        # alter code operations
-        migrations.AlterField(
-            model_name="concepttype",
-            name="code",
-            field=models.CharField(max_length=4, verbose_name="code"),
-        ),
-        migrations.AlterField(
-            model_name="currencytype",
-            name="code",
-            field=models.CharField(max_length=4, verbose_name="code"),
-        ),
-        migrations.AlterField(
-            model_name="documenttype",
-            name="code",
-            field=models.CharField(max_length=4, verbose_name="code"),
-        ),
-        migrations.AlterField(
-            model_name="optionaltype",
-            name="code",
-            field=models.CharField(max_length=4, verbose_name="code"),
-        ),
-        migrations.AlterField(
-            model_name="receipttype",
-            name="code",
-            field=models.CharField(max_length=4, verbose_name="code"),
-        ),
-        migrations.AlterField(
-            model_name="taxtype",
-            name="code",
-            field=models.CharField(max_length=4, verbose_name="code"),
-        ),
-        migrations.AlterField(
-            model_name="vattype",
-            name="code",
-            field=models.CharField(max_length=4, verbose_name="code"),
         ),
     ]

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -319,6 +319,22 @@ class CurrencyType(GenericAfipType):
         verbose_name_plural = _("currency types")
 
 
+class OptionalType(GenericAfipType):
+    """An AFIP optional type.
+
+    See the AFIP's documentation for details on each optional type.
+    """
+
+    objects = GenericAfipTypeManager("FEParamGetTiposOpcional", "OpcionalTipo")
+
+    def __str__(self) -> str:
+        return f"{self.description} ({self.code})"
+
+    class Meta:
+        verbose_name = _("optional type")
+        verbose_name_plural = _("optional types")
+
+
 class TaxPayer(models.Model):
     """Represents an AFIP TaxPayer.
 
@@ -1637,6 +1653,30 @@ class Vat(models.Model):
     class Meta:
         verbose_name = _("vat")
         verbose_name_plural = _("vat")
+
+
+class Optional(models.Model):
+    """A optional (type+value) for a specific Receipt."""
+
+    optional_type = models.ForeignKey(
+        OptionalType,
+        verbose_name=_("optional type"),
+        on_delete=models.PROTECT,
+    )
+    value = models.CharField(
+        _("optional value"),
+        max_length=250
+    )
+
+    receipt = models.ForeignKey(
+        Receipt,
+        related_name="optionals",
+        on_delete=models.PROTECT,
+    )
+
+    class Meta:
+        verbose_name = _("optional")
+        verbose_name_plural = _("optionals")
 
 
 class Observation(models.Model):

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -182,7 +182,7 @@ class GenericAfipType(models.Model):
 
     code = models.CharField(
         _("code"),
-        max_length=3,
+        max_length=4,
     )
     description = models.CharField(
         _("description"),

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -182,7 +182,7 @@ class GenericAfipType(models.Model):
 
     code = models.CharField(
         _("code"),
-        max_length=4,
+        max_length=3,
     )
     description = models.CharField(
         _("description"),

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -1198,7 +1198,6 @@ class Receipt(models.Model):
 
     objects = ReceiptManager()
 
-    # TODO: Not implemented: optionals
     # TODO: methods to validate totals
 
     @property

--- a/django_afip/serializers.py
+++ b/django_afip/serializers.py
@@ -60,6 +60,7 @@ def serialize_multiple_receipts(receipts):
 def serialize_receipt(receipt):
     taxes = receipt.taxes.all()
     vats = receipt.vat.all()
+    optionals = receipt.optionals.all()
 
     serialized = f.FECAEDetRequest(
         Concepto=receipt.concept.code,
@@ -81,6 +82,8 @@ def serialize_receipt(receipt):
     if int(receipt.concept.code) in (2, 3):
         serialized.FchServDesde = serialize_date(receipt.service_start)
         serialized.FchServHasta = serialize_date(receipt.service_end)
+
+    if receipt.expiration_date is not None:
         serialized.FchVtoPago = serialize_date(receipt.expiration_date)
 
     if taxes:
@@ -88,6 +91,9 @@ def serialize_receipt(receipt):
 
     if vats:
         serialized.Iva = f.ArrayOfAlicIva([serialize_vat(vat) for vat in vats])
+
+    if optionals:
+        serialized.Opcionales = f.ArrayOfOpcional([serialize_optional(optional) for optional in optionals])
 
     related_receipts = receipt.related_receipts.all()
     if related_receipts:
@@ -120,6 +126,13 @@ def serialize_vat(vat):
         Id=vat.vat_type.code,
         BaseImp=vat.base_amount,
         Importe=vat.amount,
+    )
+
+
+def serialize_optional(optional):
+    return f.Opcional(
+        Id=optional.optional_type.code,
+        Valor=optional.value,
     )
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,6 +13,8 @@ from django_afip.factories import ReceiptValidationFactory
 from django_afip.factories import ReceiptWithApprovedValidation
 from django_afip.factories import ReceiptWithInconsistentVatAndTaxFactory
 from django_afip.factories import ReceiptWithVatAndTaxFactory
+from django_afip.factories import ReceiptFCEAWithVatAndTaxFactory
+from django_afip.factories import ReceiptFCEAWithVatTaxAndOptionalsFactory
 
 
 def test_default_receipt_queryset():
@@ -76,6 +78,31 @@ def test_validate_invoice(populated_db):
     assert len(errs) == 0
     assert receipt.validation.result == models.ReceiptValidation.RESULT_APPROVED
     assert models.ReceiptValidation.objects.count() == 1
+
+
+@pytest.mark.django_db()
+@pytest.mark.live()
+def test_validate_fcea_invoice(populated_db):
+    """Test validating valid receipts."""
+
+    receipt = ReceiptFCEAWithVatTaxAndOptionalsFactory()
+    errs = receipt.validate()
+
+    assert len(errs) == 0
+    assert receipt.validation.result == models.ReceiptValidation.RESULT_APPROVED
+    assert models.ReceiptValidation.objects.count() == 1
+
+
+@pytest.mark.django_db()
+@pytest.mark.live()
+def test_fail_validate_fcea_invoice(populated_db):
+    """Test case to ensure that an invalid FCEA invoice fails."""
+
+    receipt = ReceiptFCEAWithVatAndTaxFactory()
+    errs = receipt.validate()
+
+    assert len(errs) == 1
+    assert models.ReceiptValidation.objects.count() == 0
 
 
 @pytest.mark.django_db()


### PR DESCRIPTION
This PR introduces support for Optionals in Receipts, specifically for use in FCEA. The implementation includes two new models: OptionalType and Optional. The code length for OptionalType was increased from 3 to 4 in the migrations to handle codes of length 4 (E.g: `2101`). see: https://github.com/Alvezgr/django-afip/blob/f9ed6a1c19bcad98e82399c089ded19363984abb/django_afip/migrations/0012_optionaltype_optional_alter_code_in_generics.py#L24

The serialize_receipt function in serializers.py file has been updated to handle the serialization of optionals. If there are any optionals associated with the receipt, they will now be included in the serialized output. see: https://github.com/Alvezgr/django-afip/blob/f9ed6a1c19bcad98e82399c089ded19363984abb/django_afip/serializers.py#L95-L96.
The serialize_optional function is also defined to handle the serialization of individual optionals.

A factory for Optional and OptionalType was added, along with a fixture to populate  data. 
Two tests cases were also created to validate the implementation. `test_validate_fcea_invoice validates` a valid FCEA with valid optionals, while `test_fail_validate_fcea_invoice` tests the case where no optionals are present.

Some hints were suggested in https://github.com/WhyNotHugo/django-afip/issues/180#issuecomment-1504083229

closes: #180 