### PR TITLE
Add AFIP Otionals description to docs, changelog.rst and api.rst

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -18,6 +18,8 @@ These are the code models which will normally be used for  ``Receipt`` validatio
     :members:
 .. autoclass:: django_afip.models.Vat
     :members:
+.. autoclass:: django_afip.models.Optional
+    :members:
 
 PDF-related models
 ------------------
@@ -56,6 +58,8 @@ command, or the ``load_metadata`` function:
 .. autoclass:: django_afip.models.TaxType
     :members:
 .. autoclass:: django_afip.models.VatType
+    :members:
+.. autoclass:: django_afip.models.OptionalType
     :members:
 
 Managers

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,7 +4,7 @@ API
 Core models
 -----------
 
-These are the code models which will normally be used for  ``Receipt`` validation.
+These are the core models which will normally be used for  ``Receipt`` validation.
 
 .. autoclass:: django_afip.models.PointOfSales
     :members:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,10 @@ acá.
 ------
 
 - Python 3.11 is now supported.
+- Added support for AFIP Optionals, especially for use in FCEA receipts
+``OptionalType`` and ``Optional`` models were added.
+- ``serialize_optional`` function was created to handle the serialization of individual optionals.
+
 
 11.1.0
 ------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,9 +11,8 @@ acá.
 ------
 
 - Python 3.11 is now supported.
-- Added support for AFIP Optionals, especially for use in FCEA receipts
-``OptionalType`` and ``Optional`` models were added.
-- ``serialize_optional`` function was created to handle the serialization of individual optionals.
+- Added support for AFIP Optionals, especially for use in FCEA receipts: ``OptionalType`` and ``Optional`` models were added.
+- Serialization of individual optionals was implemented as ``serialize_optional``.
 
 
 11.1.0


### PR DESCRIPTION
Added missing changelog for 11.2.0 for AFIP Optionals support as suggested in https://github.com/WhyNotHugo/django-afip/pull/181#issuecomment-1506644473.

Improve core models and metadata models with ``Optional`` and ``OptionalType`` autoclass as suggested in: https://github.com/WhyNotHugo/django-afip/pull/181#issuecomment-1506645094