### PR TITLE
update import to work with django < 4.2

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,9 +10,14 @@ from unittest.mock import call
 from unittest.mock import patch
 
 import pytest
+from django import VERSION as DJANGO_VERSION
 from django.db.models import DecimalField
 from freezegun import freeze_time
-from pytest_django.asserts import assertQuerySetEqual
+
+if DJANGO_VERSION[0] < 5:
+    from pytest_django.asserts import assertQuerysetEqual as assertQuerySetEqual
+else:
+    from pytest_django.asserts import assertQuerySetEqual
 
 from django_afip import exceptions
 from django_afip import factories

--- a/tests/test_webservices.py
+++ b/tests/test_webservices.py
@@ -7,9 +7,14 @@ from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
+from django import VERSION as DJANGO_VERSION
 from django.core import management
 from factory.django import FileField
-from pytest_django.asserts import assertQuerySetEqual
+
+if DJANGO_VERSION[0] < 5:
+    from pytest_django.asserts import assertQuerysetEqual as assertQuerySetEqual
+else:
+    from pytest_django.asserts import assertQuerySetEqual
 
 from django_afip import exceptions
 from django_afip import factories


### PR DESCRIPTION
trying to run tests with django versions < 4.2 threw an import error since assertQuerySetEqual was named assertQuerysetEqual, with a lowercase "s" in "set":
```
tests/test_webservices.py:12: in <module>
    from pytest_django.asserts import assertQuerySetEqual
E   ImportError: cannot import name 'assertQuerySetEqual' from 'pytest_django.asserts'
```
this swaps the right name in according to django's version.