### PR TITLE
fix(admin): make ReceiptTypeFilter noop if no filters provided

### DIFF
--- a/django_afip/admin.py
+++ b/django_afip/admin.py
@@ -142,7 +142,7 @@ class ReceiptStatusFilter(admin.SimpleListFilter):
             return queryset.exclude(
                 validation__result=models.ReceiptValidation.RESULT_APPROVED
             )
-        return queryset.none()
+        return queryset
 
 
 class ReceiptTypeFilter(admin.SimpleListFilter):

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -232,6 +232,24 @@ def test_validation_filters(admin_client: Client) -> None:
         html=True,
     )
 
+    response = admin_client.get("/admin/afip/receipt/")
+    assert isinstance(response, HttpResponse)
+    assertContains(
+        response,
+        html.format(validated_receipt.pk, str(validated_receipt)),
+        html=True,
+    )
+    assertContains(
+        response,
+        html.format(not_validated_receipt.pk, str(not_validated_receipt)),
+        html=True,
+    )
+    assertContains(
+        response,
+        html.format(failed_validation_receipt.pk, str(failed_validation_receipt)),
+        html=True,
+    )
+
 
 @pytest.mark.django_db()
 def test_receipt_admin_get_exclude() -> None:


### PR DESCRIPTION
I believe _all_ receipts should be returned rather than none, similar to what is done for the receipt type filter: https://github.com/WhyNotHugo/django-afip/blob/7958eb42dcd741e66daa0a12a66b026e05a9be44/django_afip/admin.py#L163-L169

Unless this is deliberate? If it is, then it's probably best to change the Admin View filters to say "None" instead of "All".

<details>
<summary>Admin View</summary>


Before: 

![image](https://github.com/WhyNotHugo/django-afip/assets/32206519/a1e40b58-2f49-4594-96ce-fd7f2538be2d)

After this change:

![image](https://github.com/WhyNotHugo/django-afip/assets/32206519/3ab66d3f-77b1-4f91-9515-8464cae0950d)

</details>



PD: de nuevo, tremendo proyecto este, loco! 

