### PR TITLE
fix: `validate()` to skip already validated receipts

### DIFF
--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -949,7 +949,7 @@ class ReceiptQuerySet(models.QuerySet):
         client = clients.get_client("wsfe", first.point_of_sales.owner.is_sandboxed)
         response = client.service.FECAESolicitar(
             serializers.serialize_ticket(ticket),
-            serializers.serialize_multiple_receipts(self),
+            serializers.serialize_multiple_receipts(qs),
         )
         check_response(response)
         errs = []
@@ -959,7 +959,7 @@ class ReceiptQuerySet(models.QuerySet):
                     result=cae_data.Resultado,
                     cae=cae_data.CAE,
                     cae_expiration=parsers.parse_date(cae_data.CAEFchVto),
-                    receipt=self.get(
+                    receipt=qs.get(
                         receipt_number=cae_data.CbteDesde,
                     ),
                     processed_date=parsers.parse_datetime(
@@ -978,7 +978,7 @@ class ReceiptQuerySet(models.QuerySet):
                     errs.append(f"Error {obs.Code}: {parsers.parse_string(obs.Msg)}")
 
         # Remove the number from ones that failed to validate:
-        self.filter(validation__isnull=True).update(receipt_number=None)
+        qs.filter(validation__isnull=True).update(receipt_number=None)
 
         return errs
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -117,7 +117,7 @@ def test_skip_validated_invoice(populated_db: None) -> None:
 
     # Validate them both together, the first one should be skipped
     original_cae, original_receipt_number = receipt.validation.cae, receipt.receipt_number
-    qs : ReceiptQuerySet = models.Receipt.objects.filter(pk__in=[receipt.pk, receipt2.pk])
+    qs: ReceiptQuerySet = models.Receipt.objects.filter(pk__in=[receipt.pk, receipt2.pk])  # type: ignore[assignment]
     errs = qs.validate()
     assert len(errs) == 0
     assert models.ReceiptValidation.objects.count() == 2

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -117,7 +117,7 @@ def test_skip_validated_invoice(populated_db: None) -> None:
 
     # Validate them both together, the first one should be skipped
     original_cae, original_receipt_number = receipt.validation.cae, receipt.receipt_number
-    qs = models.Receipt.objects.filter(pk__in=[receipt.pk, receipt2.pk])
+    qs : ReceiptQuerySet = models.Receipt.objects.filter(pk__in=[receipt.pk, receipt2.pk])
     errs = qs.validate()
     assert len(errs) == 0
     assert models.ReceiptValidation.objects.count() == 2


### PR DESCRIPTION
I'm testing with `@pytest.mark.live()` because I wanted to reproduce the exception one would get from the call to AFIP:

```
django_afip.exceptions.AfipException: Error 10016: El numero o fecha del comprobante no se corresponde con el proximo a autorizar. Consultar metodo FECompUltimoAutorizado.
```
