### PR TITLE
Fix dynamic receipt date offset

### DIFF
--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -77,6 +77,8 @@ CLIENT_VAT_CONDITIONS = (
     "IVA no alcanzado",
 )
 
+RECEIPT_DATE_OFFSET = {"1": 5, "2": 14, "3": 14}
+
 
 def load_metadata() -> None:
     """Loads metadata from fixtures into the database."""
@@ -1367,7 +1369,9 @@ class Receipt(models.Model):
             .last()
         )
 
-        fortnight_ago = today - timedelta(days=14)
+        fortnight_ago = today - timedelta(
+            days=RECEIPT_DATE_OFFSET[str(self.concept.code)]
+        )
         if most_recent is None:
             oldest_possible = fortnight_ago
         else:

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -1346,7 +1346,7 @@ class Receipt(models.Model):
 
             - Receipts can only be validated with dates as far as 14 days ago for services
               and 5 days ago for products. If the receipt date is older than that, set
-              it to 14 days ago.
+              it to 14 or 5 days ago.
             - If other receipts have been validated on a more recent date, the receipt
               cannot be older than the most recent one.
 

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -1345,9 +1345,9 @@ class Receipt(models.Model):
         If a receipt should have been validated in a past date, adjust its date as close
         as possible:
 
-            - Receipts can only be validated with dates as far as 14 days ago for services
-              and 5 days ago for products. If the receipt date is older than that, set
-              it to 14 or 5 days ago.
+            - Receipts can only be validated with dates as far as 14 days ago for 
+              services and 5 days ago for products. If the receipt date is older 
+              than that, set it to 14 or 5 days ago.
             - If other receipts have been validated on a more recent date, the receipt
               cannot be older than the most recent one.
 

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -1344,8 +1344,9 @@ class Receipt(models.Model):
         If a receipt should have been validated in a past date, adjust its date as close
         as possible:
 
-            - Receipts can only be validated with dates as far as 14 days ago. If the
-              receipt date is older than that, set it to 14 days ago.
+            - Receipts can only be validated with dates as far as 14 days ago for services
+              and 5 days ago for products. If the receipt date is older than that, set
+              it to 14 days ago.
             - If other receipts have been validated on a more recent date, the receipt
               cannot be older than the most recent one.
 

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -77,6 +77,7 @@ CLIENT_VAT_CONDITIONS = (
     "IVA no alcanzado",
 )
 
+# Keys: ConceptType.code, Values: maximum days ago.
 RECEIPT_DATE_OFFSET = {"1": 5, "2": 14, "3": 14}
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -530,7 +530,6 @@ def test_approximate_date_today_with_most_recent() -> None:
     today = datetime.now(TZ_AR).date()
 
     factories.ReceiptWithApprovedValidation(issued_date=today)
-
     receipt = factories.ReceiptFactory(issued_date=today - timedelta(days=30))
     changed = receipt.approximate_date()
 
@@ -563,7 +562,7 @@ def test_approximate_date_30_days_ago_with_most_recent_20_days_ago() -> None:
     changed = receipt.approximate_date()
 
     assert changed is True
-    assert receipt.issued_date == date(2023, 11, 2)
+    assert receipt.issued_date == date(2023, 11, 11)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This PR adds `RECEIPT_DATE_OFFSET` dict which contains date offsets to `approximate date`.
Based on [AFIP - manual desarrollador](https://www.afip.gob.ar/ws/WSFEV1/documentos/manual-desarrollador-COMPG-v3-4-2.pdf) 

> Fecha del comprobante (yyyymmdd).
Para concepto igual a 1, la fecha de emisión del comprobante puede ser hasta 5 días anteriores o posteriores respecto de la fecha de generación: La misma no podrá exceder el mes de presentación. Si se indica Concepto igual a 2 ó 3 puede ser hasta 10 días anteriores o posteriores a la fecha de generación. Si no se envía la fecha del comprobante se asignará la fecha de proceso

Should solve https://github.com/WhyNotHugo/django-afip/issues/225
FYI @WhyNotHugo 