### PR TITLE
fix: avoid double fixture load for clientvarcondition

### DIFF
--- a/django_afip/locale/es/LC_MESSAGES/django.po
+++ b/django_afip/locale/es/LC_MESSAGES/django.po
@@ -416,6 +416,12 @@ msgstr "La cotización de la moneda en el día que fue emitido este comprobante.
 msgid "related receipts"
 msgstr "comprobantes relacionados"
 
+msgid "client VAT condition"
+msgstr "condición IVA del cliente"
+
+msgid "The client VAT condition of the recipient of this receipt."
+msgstr "La condición frente al IVA del cliente para el cual este comprobante es emitido."
+
 #, python-format
 msgid "Unnumbered %s"
 msgstr "%s sin número"

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -1890,6 +1890,20 @@ class ReceiptValidation(models.Model):
         verbose_name_plural = _("receipt validations")
 
 
+class ClientVatConditionManager(models.Manager):
+    """Manager for ClientVatCondition.
+
+    This class is only used to provide natural key support for the
+    :class:`~.ClientVatCondition` class.
+    """
+
+    def get_by_natural_key(self, code: str) -> ClientVatCondition:
+        return self.get(code=code)
+
+    def exists_by_natural_key(self, code: str) -> bool:
+        return self.filter(code=code).exists()
+
+
 class ClientVatCondition(models.Model):
     """Client VAT condition for certain types of Receipts.
 
@@ -1897,6 +1911,8 @@ class ClientVatCondition(models.Model):
     different from the others returned by AFIP. All other metadata types share the same
     set of fields. This one has different fields, so is modelled separately.
     """
+
+    objects = ClientVatConditionManager()
 
     code = models.CharField(
         _("code"),
@@ -1951,6 +1967,9 @@ class ClientVatCondition(models.Model):
                     "cmp_clase": condition_data.Cmp_Clase,
                 },
             )
+
+    def natural_key(self) -> tuple[str]:
+        return (self.code,)
 
     def __str__(self) -> str:
         return f"{self.description}"

--- a/django_afip/models.py
+++ b/django_afip/models.py
@@ -1953,4 +1953,4 @@ class ClientVatCondition(models.Model):
             )
 
     def __str__(self) -> str:
-        return f"{self.description} ({self.code})"
+        return f"{self.description}"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -643,3 +643,34 @@ def test_client_vat_condition_populate(live_ticket: models.AuthTicket) -> None:
     initial_count = models.ClientVatCondition.objects.count()
     models.ClientVatCondition.populate(ticket=live_ticket)
     assert models.ClientVatCondition.objects.count() == initial_count
+
+
+@pytest.mark.django_db
+def test_load_metadata() -> None:
+    """Test populating AFIP models from fixtures."""
+    fetched_models = [
+        models.ClientVatCondition,
+        models.ConceptType,
+        models.CurrencyType,
+        models.DocumentType,
+        models.OptionalType,
+        models.ReceiptType,
+        models.TaxType,
+        models.VatType,
+    ]
+
+    # At first we have no data
+    for m in fetched_models:
+        assert m.objects.count() == 0
+
+    # Load data and expect data
+    models.load_metadata()
+    counts = []
+    for m in fetched_models:
+        assert m.objects.count() > 0
+        counts.append(m.objects.count())
+
+    # Load data again and expect no change
+    models.load_metadata()
+    for i, m in enumerate(fetched_models):
+        assert m.objects.count() == counts[i]


### PR DESCRIPTION
I noticed running `python manage.py afipmetadata` multiple times loaded the `ClientVatCondition` fixture multiple times. This fixes that using natural keys, just like `GenericAfipType` does. 

Piggybacking two minor changes:
* Add Spanish translations for `ClientVatCondition` strings
* Remove the `(code)` string from `ClientVatCondition`'s `__str__`, matching what `GenericAfipType` does