### PR TITLE
Add support for Django 6.1

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,11 @@ Check the `latest tags`_ or `PyPI`_ for the latest stable release.
 
 Any breaking changes which require intervention will be mentioned here.
 
+14.1.0
+------
+
+- Add support for Django 6.1.
+
 14.0.0
 ------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
   "Framework :: Django",
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",
+  "Framework :: Django :: 6.1",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
@@ -29,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
   "cryptography>=3.2,<47",
-  "django>=5.2,<6.1",
+  "django>=5.2,<7.0",
   "django_renderpdf>=6.0.0,<7.0.0",
   "lxml>=3.4.4,<7.0.0",
   "pyopenssl>=16.2.0",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ isolated_build = True
 envlist =
   mypy,docs,ruff,vermin
   py{310,311,312,313,314}-django52-{postgres,mysql}
-  py{312,313,314}-django60-{postgres,mysql}
+  py{312,313,314}-django{60,61}-{postgres,mysql}
 skip_missing_interpreters = True
 
 [testenv]
@@ -12,6 +12,7 @@ extras = dev
 deps =
   django52: Django>=5.2,<5.3
   django60: Django>=6.0,<6.1
+  django61: Django>=6.1,<6.2
   postgres: psycopg[binary]
   mysql: mysqlclient
 commands = pytest -vv -m "not live" {posargs}


### PR DESCRIPTION
Keep the pin intentionally loose, since we know we're not using any features pending deprecation before 7.0.